### PR TITLE
Implemented functionality for expanding tilde to the home directory.

### DIFF
--- a/fsls.js
+++ b/fsls.js
@@ -9,11 +9,14 @@ module.exports = function (options, cb) {
     options.pattern = '**/*';
   }
 
+  options.pattern = expand_tilde(options.pattern);
+
   var globOpts = {
     stat: true,
     mark: true
   };
   if (options.cwd) {
+    options.cwd = expand_tilde(options.cwd);
     globOpts.cwd = options.cwd;
   }
 
@@ -22,6 +25,19 @@ module.exports = function (options, cb) {
     cb(null, glob_to_nodes(files, options));
   });
 };
+
+function expand_tilde (p) {
+  var home = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+  var tilde = '~';
+
+  p = p || '';
+
+  if (p[0] === tilde) {
+    p = p.replace(tilde, home);
+  }
+
+  return p;
+}
 
 // Convert glob() results to archy nodes structure.
 function glob_to_nodes(files, options) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -61,4 +61,24 @@ describe('tree', function () {
     });
   });
 
+   it('should be able to expand tilde in cwd', function (done) {
+     var options = {cwd: '~', pattern: '*.foo'};
+
+     fsls(options, function (err, nodes) {
+       assert.notEqual(options.cwd[0], '~');
+
+       done();
+     });
+   });
+
+   it('should be able to expand tilde in pattern', function (done) {
+     var options = {cwd: '~', pattern: '~/*.foo'};
+
+     fsls(options, function (err, nodes) {
+       assert.notEqual(options.cwd[0], '~');
+
+       done();
+     });
+   });
+
 });


### PR DESCRIPTION
With this change it is possible to use the tilde in the `cwd` and the `pattern` parameters.

`fsls "~/**/*.js"` will be expanded to `fsls "/home/<user>/**/*.js"` on a *nix system.

Thanks for putting `node-fsls` up. It is useful for validating globs :)
