### PR TITLE
Implemented functionality for printing a flat representation instead of a tree.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ $ fsls --help
     -d, --depth <depth>  Max depth of tree to print
     -s, --structure      Only show directory structure, no files
     -p, --plain          No unicode characters
+    -f, --flat           Do not print a tree, print a flat structure
     --no-color           Do not colorize output
 ```
 

--- a/bin/fsls
+++ b/bin/fsls
@@ -11,12 +11,14 @@ program
   .option('-d, --depth <depth>', 'Max depth of tree to print')
   .option('-s, --structure', 'Only show directory structure, no files')
   .option('-p, --plain', 'No unicode characters')
+  .option('-f, --flat', 'Do not print a tree, print a flat structure')
   .option('--no-color', 'Do not colorize output')
   .parse(process.argv);
 
 var options = {
   color: true,
-  unicode: true
+  unicode: true,
+  flat: false
 };
 if (program.cwd) {
   options.cwd = program.cwd;
@@ -37,10 +39,19 @@ if (program.color !== options.color) {
   options.color = program.color;
 }
 
+if (program.flat !== options.flat) {
+  options.flat = !!program.flat;
+}
+
 fsls(options, function (err, nodes) {
   if (err) return console.error(err);
   if (options.color) colorize(nodes);
-  console.log(archy(nodes, ' ', options));
+
+  if (!options.flat) {
+    console.log(archy(nodes, ' ', options));
+  } else {
+    console.log(nodes.join('\n'));
+  }
 });
 
 function colorize (nodes) {

--- a/fsls.js
+++ b/fsls.js
@@ -21,8 +21,17 @@ module.exports = function (options, cb) {
   }
 
   glob(options.pattern, globOpts, function (err, files) {
+    var result;
+
     if (err) return cb(null);
-    cb(null, glob_to_nodes(files, options));
+
+    result = files;
+
+    if (!options.flat) {
+      result = glob_to_nodes(files, options);
+    }
+
+    cb(null, result);
   });
 };
 

--- a/fsls.js
+++ b/fsls.js
@@ -9,11 +9,14 @@ module.exports = function (options, cb) {
     options.pattern = '**/*';
   }
 
+  options.pattern = expand_tilde(options.pattern);
+
   var globOpts = {
     stat: true,
     mark: true
   };
   if (options.cwd) {
+    options.cwd = expand_tilde(options.cwd);
     globOpts.cwd = options.cwd;
   }
 
@@ -22,6 +25,19 @@ module.exports = function (options, cb) {
     cb(null, glob_to_nodes(files, options));
   });
 };
+
+function expand_tilde (p) {
+  var home = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+  var tilde = '~';
+
+  p = p || '';
+
+  if (p[0] === tilde) {
+    p = p.replace(tilde, home);
+  }
+
+  return p;
+}
 
 // Convert glob() results to archy nodes structure.
 function glob_to_nodes(files, options) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -81,4 +81,21 @@ describe('tree', function () {
      });
    });
 
+   it('should be able to return a flat representation', function (done) {
+      fsls({cwd: cwd, flat: true}, function (err, nodes) {
+        assert.ifError(err);
+
+        assert.deepEqual(nodes, [
+          'more/',
+          'more/bar.txt',
+          'more/deeper/',
+          'more/deeper/baz.js',
+          'more/foo.js',
+          'test.js'
+        ]);
+        
+        done();
+      });
+   });
+
 });

--- a/test/basic.js
+++ b/test/basic.js
@@ -61,4 +61,24 @@ describe('tree', function () {
     });
   });
 
+   it('should be able to expand tilde in cwd', function (done) {
+     var options = {cwd: '~', pattern: '*.foo'};
+
+     fsls(options, function (err, nodes) {
+       assert.notEqual(options.cwd[0], '~');
+
+       done();
+     });
+   });
+
+   it('should be able to expand tilde in pattern', function (done) {
+     var options = {cwd: '~', pattern: '~/*.foo'};
+
+     fsls(options, function (err, nodes) {
+       assert.notEqual(options.cwd[0], '~');
+
+       done();
+     });
+   });
+
 });


### PR DESCRIPTION
`fsls "~/projects/*/README.md" --flat`

Will print

```
/home/akoenig/project1/README.md
/home/akoenig/project2/README.md
/home/akoenig/project3/README.md
/home/akoenig/project4/README.md
```

Hope you like it :)
